### PR TITLE
Change BR2_EXTERNAL to BR2_EXTERNAL_COREOS, and add desc file

### DIFF
--- a/Config.in
+++ b/Config.in
@@ -1,1 +1,1 @@
-source "$BR2_EXTERNAL/package/Config.in"
+source "$BR2_EXTERNAL_COREOS/package/Config.in"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Step 3 - Reference the `coreos_buildroot` directory from `buildroot`:
 
 ```
 $ cd buildroot
-$ make BR2_EXTERNAL=../coreos_buildroot menuconfig
+$ make BR2_EXTERNAL_COREOS=../coreos_buildroot menuconfig
 ```
 This connects the two repos together and exposes all of the coreos_buildroot
 options through the menu option `"User-provided options  --->"`

--- a/external.desc
+++ b/external.desc
@@ -1,0 +1,1 @@
+name: COREOS

--- a/external.mk
+++ b/external.mk
@@ -1,1 +1,1 @@
-include $(sort $(wildcard $(BR2_EXTERNAL)/package/*/*.mk))
+include $(sort $(wildcard $(BR2_EXTERNAL_COREOS)/package/*/*.mk))

--- a/package/Config.in
+++ b/package/Config.in
@@ -1,3 +1,3 @@
 menu "Networking applications"  
-	source "$BR2_EXTERNAL/package/openresty/Config.in"
+	source "$BR2_EXTERNAL_COREOS/package/openresty/Config.in"
 endmenu


### PR DESCRIPTION
The instructions currently fail if the newest version of buildroot is grabbed off Github. According to the buildroot docs, this envvar needs to be updated. I followed the guide here:

https://buildroot.org/downloads/manual/manual.html#br2-external-converting

The instructions worked once this change was made