### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ cd buildroot
 $ make BR2_EXTERNAL=../coreos_buildroot menuconfig
 ```
 This connects the two repos together and exposes all of the coreos_buildroot
-options through the menu option `"User-provided options  --->"`
+options through the menu option `"External options  --->"`
 
 ## Using CoreOS Buildroot
 


### PR DESCRIPTION
Changed "User-provided options" to read "External options".

_I think this is correct, at least on the version of Buildroot that I have, '2017.11-git-00735-g9d6da7a264'._